### PR TITLE
Updating github-activity-metrics-tool.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 inputs/*
 outputs/*
 archive/*
+sandbox/*
+test/*
 logs/*
 
 # Byte-compiled / optimized / DLL files

--- a/template.env
+++ b/template.env
@@ -1,7 +1,8 @@
 {
 "githubtoken":"",
+"zenodoToken":""
 "institutionname":"UT Austin",
-"institutionnamepermutations":["UT Austin", "University of Texas at Austin", "UT", "University of Texas, Austin", "UT-Austin"],
+"institutionnamepermutations":["Texas Advanced Computing Center", "TACC", "Cockrell School", "McCombs School", "Moody College", "Jackson School", "LBJ School", "Dell Medical", "McDonald Observatory", "Oden Institute", "University of Texas Institute for Geophysics", "LLILAS Benson", "UT Austin", "The University of Texas at Austin", "University of Texas at Austin", "University of Texas, Austin", "UT-Austin", "UT, Austin", "University of Texas-Austin", "UT"],
 "institutioncity":"Austin",
 "institutionemaildomain":"utexas.edu",
 "githubaccountdetailscsvpath":"outputs/github-account-list-institutionnameplaceholder-dateplaceholder-detaillevelplaceholder.csv",
@@ -11,7 +12,7 @@
 "minimumfollowers":0,
 "minimumrepos":1,
 "detaillevel":"fulldetail",
-"githubrepolastupdatethresholdinmonths":24,
-"githubaccountdatacsvpathforvisualization":"outputs/2024-10-02/github-account-list-ut-austin-2024-10-02.csv",
-"githubrepodatacsvpathforvisualization":"outputs/2024-10-02/github-repo-list-ut-austin-2024-10-02.csv"
+"githubrepolastupdatethresholdinmonths":84,
+"githubaccountdatacsvpathforvisualization":"outputs/2024-11-07/github-account-list-ut-austin-2024-10-02.csv",
+"githubrepodatacsvpathforvisualization":"outputs/2024-11-07/github-repo-list-ut-austin-2024-10-02.csv"
 }


### PR DESCRIPTION
Changes include:

- Fixing export path for files (subfolder with today's date created, but files not deposited in that subfolder)
- Added additional queries for UT Austin (subsidiary schools, institutes, centers, etc.)
- Added toggle for 'test' environment (here it queries only low-output strings, runtime is 5 minutes)
- Added toggle for manually implemented rate limiting
- Added functionality in requests for conditional rate limiting and delay if 5,000/hr limit is approached or hit
- Added functionality to ensure all pages of repo results for a given account are retrieved
- Added functionality to identify which affiliation is detected based on list of permutations in .env file (separate from query parameters in script itself)